### PR TITLE
rubocop実行

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -28,7 +28,7 @@ class SessionsController < ApplicationController
       start_new_session_for user
       redirect_to after_authentication_url
     else
-      flash.now[:alert] = ["メールアドレスまたはパスワードが正しくありません。"]
+      flash.now[:alert] = [ "メールアドレスまたはパスワードが正しくありません。" ]
       render :new, status: :unprocessable_entity
     end
   end


### PR DESCRIPTION
close #14 

## やったこと
- `$ bundle exec rubocop -a`を実行してコードを修正
- rubocopの設定が必要だったわけではなく、rubocopでのコード修正が実行されていなかったことが原因でlintエラーが発生していた